### PR TITLE
removed common labels and hash on configmap

### DIFF
--- a/kubernetes/base/deployment.yml
+++ b/kubernetes/base/deployment.yml
@@ -5,6 +5,11 @@ metadata:
   namespace: ${NAMESPACE}
   labels:
     service: app
+  annotations:
+    repositoryUrl: ${BUILD_REPOSITORY_URI}
+    commit: ${COMMIT}
+    tag: ${TAG}
+    image: ${IMAGE}
 spec:
   selector:
     matchLabels:

--- a/kubernetes/base/kustomization.yml
+++ b/kubernetes/base/kustomization.yml
@@ -8,7 +8,6 @@ resources:
 configurations:
   - configuration.yml
 
-
 # Add composite env vars from secrets
 patches:
   - target:
@@ -28,11 +27,8 @@ commonLabels:
   app: ${BUILD_REPOSITORY_NAME}
   source: ${BUILD_REPOSITORY_NAME}
 
-commonAnnotations:
-  repositoryUrl: ${BUILD_REPOSITORY_URI}
-  commit: ${COMMIT}
-  tag: ${TAG}
-  image: ${IMAGE}
+generatorOptions:
+  disableNameSuffixHash: true
 
 configMapGenerator:
 - name: env

--- a/kubernetes/envs/Dev/kustomization.yml
+++ b/kubernetes/envs/Dev/kustomization.yml
@@ -1,6 +1,9 @@
 resources:
   - ../../base
 
+generatorOptions:
+  disableNameSuffixHash: true
+
 configMapGenerator:
 - name: env
   namespace: ${NAMESPACE}

--- a/kubernetes/envs/Prod/kustomization.yml
+++ b/kubernetes/envs/Prod/kustomization.yml
@@ -1,6 +1,9 @@
 resources:
   - ../../base
 
+generatorOptions:
+  disableNameSuffixHash: true
+
 configMapGenerator:
 - name: env
   namespace: ${NAMESPACE}

--- a/kubernetes/envs/Staging/kustomization.yml
+++ b/kubernetes/envs/Staging/kustomization.yml
@@ -1,6 +1,9 @@
 resources:
   - ../../base
 
+generatorOptions:
+  disableNameSuffixHash: true
+
 configMapGenerator:
 - name: env
   namespace: ${NAMESPACE}


### PR DESCRIPTION
this PR is removing all general annotations which are different per deployment, and moving them to deployment.yml only. Also configmap and secret hash are disabled.

We are doing this steps to avoid redeploying statefull sets like postgress every time strapi or next is deployed.