### PR TITLE
fix: prod scalling when 2+ instances are up

### DIFF
--- a/kubernetes/envs/Prod/scaler.yml
+++ b/kubernetes/envs/Prod/scaler.yml
@@ -15,10 +15,10 @@ spec:
         serverAddress: http://kube-prometheus-prometheus.monitoring.svc.cluster.local:9090
         metricName: container_cpu_usage_percent
         threshold: '85'
-        query: 100 * (sum(rate(container_cpu_usage_seconds_total{namespace="${NAMESPACE}", pod=~"${BUILD_REPOSITORY_NAME}-app.*", container=~".*"}[10m])) by (namespace, pod, container) / on (pod, container) group_left() kube_pod_container_resource_limits{namespace="${NAMESPACE}", pod=~"${BUILD_REPOSITORY_NAME}-app.*", container=~".*", resource="cpu"})
+        query: max(100 * (sum(rate(container_cpu_usage_seconds_total{namespace="${NAMESPACE}", pod=~"${BUILD_REPOSITORY_NAME}-app.*", container=~".*"}[10m])) by (namespace, pod, container) / on (pod, container) group_left() kube_pod_container_resource_limits{namespace="${NAMESPACE}", pod=~"${BUILD_REPOSITORY_NAME}-app.*", container=~".*", resource="cpu"}))
     - type: prometheus
       metadata:
         serverAddress: http://kube-prometheus-prometheus.monitoring.svc.cluster.local:9090
         metricName: container_memory_usage_percent
         threshold: '85'
-        query: sum by (namespace, pod) (100 * (avg_over_time(container_memory_working_set_bytes{namespace="${NAMESPACE}", pod=~"${BUILD_REPOSITORY_NAME}-app.*", service="kube-prometheus-kubelet"}[10m]) / on (pod, container) group_left() kube_pod_container_resource_limits{resource="memory", namespace="${NAMESPACE}", pod=~"${BUILD_REPOSITORY_NAME}-app.*"}))
+        query: max(sum by (namespace, pod) (100 * (avg_over_time(container_memory_working_set_bytes{namespace="${NAMESPACE}", pod=~"${BUILD_REPOSITORY_NAME}-app.*", service="kube-prometheus-kubelet"}[10m]) / on (pod, container) group_left() kube_pod_container_resource_limits{resource="memory", namespace="${NAMESPACE}", pod=~"${BUILD_REPOSITORY_NAME}-app.*"})))


### PR DESCRIPTION
* Keda needs only one time-series to make decisions, so when there were 2+ instances of application it receive multiple ones and thrown an error. Which led to PODs being able to scale up but not scale down due to error state.
* Added `max()` function in front of the metrics, as we want to most likely always compare the highest value. Individual metrics for PODs are averaged/summed over time