### PR TITLE
Remove storageClass specification and set modest DB sizes

### DIFF
--- a/kubernetes/base/stateful-set.yml
+++ b/kubernetes/base/stateful-set.yml
@@ -41,7 +41,6 @@ spec:
           service: database
       spec:
         accessModes: ['ReadWriteOnce']
-        storageClassName: "vsan-default-storage-policy"
         resources:
           requests:
-            storage: 10Gi
+            storage: ${DB_SIZE}

--- a/kubernetes/envs/Dev/config.json
+++ b/kubernetes/envs/Dev/config.json
@@ -7,6 +7,7 @@
       "DB_CPU_LIMITS": "100m",
       "DB_MEMORY_LIMITS": "512Mi",
       "DB_CPU_REQUESTS": "50m",
-      "DB_MEMORY_REQUESTS": "64Mi"
+      "DB_MEMORY_REQUESTS": "64Mi",
+      "DB_SIZE": "1Gi"
   }
 }

--- a/kubernetes/envs/Prod/config.json
+++ b/kubernetes/envs/Prod/config.json
@@ -7,6 +7,7 @@
       "DB_CPU_LIMITS": "500m",
       "DB_MEMORY_LIMITS": "1Gi",
       "DB_CPU_REQUESTS": "100m",
-      "DB_MEMORY_REQUESTS": "128Mi"
+      "DB_MEMORY_REQUESTS": "128Mi",
+      "DB_SIZE": "10Gi"
   }
 }

--- a/kubernetes/envs/Staging/config.json
+++ b/kubernetes/envs/Staging/config.json
@@ -7,6 +7,7 @@
       "DB_CPU_LIMITS": "500m",
       "DB_MEMORY_LIMITS": "1Gi",
       "DB_CPU_REQUESTS": "50m",
-      "DB_MEMORY_REQUESTS": "64Mi"
+      "DB_MEMORY_REQUESTS": "64Mi",
+      "DB_SIZE": "1Gi"
   }
 }


### PR DESCRIPTION
* Remove explicit declaration of `storageClass` as for this DB it is not necessary. Rather let cluster decide with default `storageClass`
* Push DB size to variable inside `config.json` and set defaults to more modest sizes for DEV and STAGING clusters